### PR TITLE
feat(generator): add dedicated team-setup question

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -102,6 +102,7 @@ const PayloadSchema = z.object({
       ])
     )
     .default([]),
+  teamSetup: z.boolean().default(false),
   license: z.enum(["MIT", "Apache-2.0", "AGPL-3.0", "none"]).default("MIT"),
   colors: z
     .object({
@@ -254,6 +255,23 @@ export async function POST(req: NextRequest) {
     if (!info) continue;
     const buf = await readBuf(path.join(templatesRoot, info.src));
     if (buf) files.push({ name: info.dest, content: buf, mode: info.mode });
+  }
+
+  // Team setup — dedicated question (separate from extras list).
+  // When enabled, mirror templates/extras/team/ into the project root,
+  // preserving subpaths (CONTRIBUTING.md, CODEOWNERS, .github/...).
+  if (payload.teamSetup) {
+    const teamDir = path.join(templatesRoot, "extras", "team");
+    try {
+      const teamFiles = await walk(teamDir);
+      for (const fileAbs of teamFiles) {
+        const rel = path.relative(teamDir, fileAbs).split(path.sep).join("/");
+        const buf = await fs.readFile(fileAbs);
+        files.push({ name: rel, content: buf });
+      }
+    } catch {
+      // Team tree missing on disk — skip silently.
+    }
   }
 
   // Add .dockerignore automatically if dockerfile or docker-compose chosen

--- a/components/Questionnaire.tsx
+++ b/components/Questionnaire.tsx
@@ -124,6 +124,7 @@ function buildSchema(messages: {
     mcps: z.array(z.enum(MCP_VALUES)).default([]),
     designSystem: z.enum(["use-example", "empty-template", "skip"]),
     extras: z.array(z.enum(EXTRA_VALUES)).default([]),
+    teamSetup: z.boolean().default(false),
     license: z.enum(LICENSE_VALUES).default("MIT"),
     colors: z
       .object({
@@ -257,6 +258,7 @@ export function Questionnaire({ onValuesChange }: QuestionnaireProps = {}) {
       mcps: ["notion", "context7"],
       designSystem: "empty-template",
       extras: ["editorconfig", "prettierrc"],
+      teamSetup: false,
       license: "MIT",
       colors: DEFAULT_COLORS,
     },
@@ -457,6 +459,36 @@ export function Questionnaire({ onValuesChange }: QuestionnaireProps = {}) {
                       />
                     </RadioGroup>
                   )}
+                />
+                <Controller
+                  control={control}
+                  name="teamSetup"
+                  render={({ field }) => {
+                    const checked = field.value === true;
+                    return (
+                      <label
+                        className={`flex items-start gap-3 p-4 rounded-[10px] border cursor-pointer transition-colors ${
+                          checked
+                            ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)]"
+                            : "border-[var(--color-border)] hover:border-[var(--color-border-strong)]"
+                        }`}
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(c) => field.onChange(c === true)}
+                          className="mt-0.5"
+                        />
+                        <div className="flex-1">
+                          <div className="text-sm font-medium text-[var(--color-foreground)]">
+                            {t("step2.teamSetupLabel")}
+                          </div>
+                          <div className="text-xs text-[var(--color-muted-foreground)] mt-1">
+                            {t("step2.teamSetupDesc")}
+                          </div>
+                        </div>
+                      </label>
+                    );
+                  }}
                 />
               </div>
             )}

--- a/messages/en.json
+++ b/messages/en.json
@@ -372,7 +372,9 @@
         "greenfieldTitle": "New project (greenfield)",
         "greenfieldDesc": "We scaffold .claude/, CLAUDE.md, DESIGN.md, .mcp.json, install.sh.",
         "overlayTitle": "Existing project (overlay)",
-        "overlayDesc": "We add only the Claude files on top of your repo. Your code is untouched."
+        "overlayDesc": "We add only the Claude files on top of your repo. Your code is untouched.",
+        "teamSetupLabel": "Team setup",
+        "teamSetupDesc": "Adds CONTRIBUTING.md, CODEOWNERS, and the GitHub PR/issue templates. Recommended if multiple developers will work on the repo."
       },
       "step3": {
         "title": "Tech stack?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -372,7 +372,9 @@
         "greenfieldTitle": "Nouveau projet (greenfield)",
         "greenfieldDesc": "On scaffold .claude/, CLAUDE.md, DESIGN.md, .mcp.json, install.sh.",
         "overlayTitle": "Projet existant (overlay)",
-        "overlayDesc": "On ajoute uniquement les fichiers Claude par-dessus ton repo. Ton code n'est pas touché."
+        "overlayDesc": "On ajoute uniquement les fichiers Claude par-dessus ton repo. Ton code n'est pas touché.",
+        "teamSetupLabel": "Setup équipe",
+        "teamSetupDesc": "Ajoute CONTRIBUTING.md, CODEOWNERS, et les templates GitHub PR/issues. Recommandé si plusieurs développeurs travailleront sur le repo."
       },
       "step3": {
         "title": "Stack technique ?",


### PR DESCRIPTION
## Summary

- Adds a new `teamSetup` boolean to the questionnaire — surfaced as a dedicated checkbox in step 2 (below the greenfield/overlay radio).
- When enabled, `app/api/generate/route.ts` mirrors `templates/extras/team/` into the project root, preserving subpaths.
- Files included: `CONTRIBUTING.md`, `CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md` (already on disk, previously dormant).
- i18n keys `step2.teamSetupLabel` + `step2.teamSetupDesc` added to FR + EN.

## Why a dedicated question (not an extras checkbox)

Team setup is a higher-level decision (multi-dev workflow vs solo) — it belongs next to the greenfield/overlay mode question, not buried in the dotfile extras list.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [ ] Manual: questionnaire step 2 shows the new checkbox (FR + EN)
- [ ] Manual: POST `/api/generate` with `teamSetup: true` returns a zip containing the 5 team files
- [ ] Manual: POST without `teamSetup` (or `false`) does not include team files