### PR TITLE
fix: mobile nav CTA overflow + footer placeholder hrefs

### DIFF
--- a/components/landing/FaqCtaFooter.tsx
+++ b/components/landing/FaqCtaFooter.tsx
@@ -247,7 +247,7 @@ export function CTA() {
               }}
             >
               <a
-                href="#"
+                href="/generator"
                 className="btn btn-accent btn-arrow"
                 style={{ padding: "16px 28px", fontSize: 16 }}
               >
@@ -284,7 +284,13 @@ export function CTA() {
   );
 }
 
-function FootCol({ title, links }: { title: string; links: string[] }) {
+function FootCol({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<{ label: string; href: string; external?: boolean }>;
+}) {
   return (
     <div>
       <div className="caption" style={{ marginBottom: 20 }}>
@@ -300,17 +306,20 @@ function FootCol({ title, links }: { title: string; links: string[] }) {
           gap: 12,
         }}
       >
-        {links.map((l) => (
-          <li key={l}>
+        {items.map((it) => (
+          <li key={it.label}>
             <a
-              href="#"
+              href={it.href}
+              {...(it.external
+                ? { target: "_blank", rel: "noreferrer noopener" }
+                : {})}
               style={{
                 color: "var(--color-muted-foreground)",
                 fontSize: 14,
                 transition: "color 200ms",
               }}
             >
-              {l}
+              {it.label}
             </a>
           </li>
         ))}
@@ -377,15 +386,37 @@ export function Footer() {
 
           <FootCol
             title={t("cabinet")}
-            links={t.raw("cabinetLinks") as string[]}
+            items={(t.raw("cabinetLinks") as string[]).map((label, i) => ({
+              label,
+              href: ["/#methode", "/#expertise", "/#personas", "/#use-cases", "/#faq"][i] ?? "/",
+            }))}
           />
           <FootCol
             title={t("resources")}
-            links={t.raw("resourcesLinks") as string[]}
+            items={(t.raw("resourcesLinks") as string[]).map((label, i) => ({
+              label,
+              href: [
+                "https://github.com/jdvot/cordee-ia",
+                "https://github.com/jdvot/cordee-ia/blob/main/USE_CASES.md",
+                "https://github.com/jdvot/cordee-ia/blob/main/CONTRIBUTING.md",
+                "https://github.com/jdvot/cordee-ia/blob/main/CHANGELOG.md",
+                "https://github.com/jdvot/cordee-ia/issues",
+              ][i] ?? "https://github.com/jdvot/cordee-ia",
+              external: true,
+            }))}
           />
           <FootCol
             title={t("legal")}
-            links={t.raw("legalLinks") as string[]}
+            items={(t.raw("legalLinks") as string[]).map((label, i) => ({
+              label,
+              href: [
+                "https://github.com/jdvot/cordee-ia/blob/main/LICENSE",
+                "https://github.com/jdvot/cordee-ia#privacy",
+                "https://github.com/jdvot/cordee-ia/blob/main/CODE_OF_CONDUCT.md",
+                "mailto:julien.dvt57@gmail.com",
+              ][i] ?? "/",
+              external: i < 3,
+            }))}
           />
         </div>
 

--- a/components/landing/Nav.tsx
+++ b/components/landing/Nav.tsx
@@ -37,7 +37,9 @@ export function Nav() {
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
           <DarkToggle />
           <LanguageSwitcher variant="nav" />
-          <Link href="/generator" className="btn btn-accent">
+          {/* CTA hidden on small screens — overflowed on mobile.
+              Logo and link to /generator already accessible via the hero CTA. */}
+          <Link href="/generator" className="btn btn-accent hidden md:inline-flex">
             {t("ctaBook")} <ArrowRight size={14} />
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- Mobile: hide "Generate my starter" nav CTA below md breakpoint (was overflowing)
- Bottom CTA section: href="/generator" (was "#")
- Footer columns now accept {label, href, external} items, real URLs wired
  - Cabinet → landing anchors (/#methode, /#expertise, etc.)
  - Resources → GitHub URLs
  - Legal → LICENSE, CODE_OF_CONDUCT.md, mailto

## Test plan
- [x] typecheck + build green
- [ ] Mobile (390px) → no nav overflow
- [ ] Desktop → CTA still visible in nav
- [ ] Footer links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)