### PR TITLE
fix(nav): hide CTA on mobile (CSS not Tailwind)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -379,6 +379,9 @@ section {
   .nav-links {
     display: none;
   }
+  .nav-cta {
+    display: none !important;
+  }
   .nav-inner {
     gap: 16px;
   }

--- a/components/landing/Nav.tsx
+++ b/components/landing/Nav.tsx
@@ -37,9 +37,8 @@ export function Nav() {
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
           <DarkToggle />
           <LanguageSwitcher variant="nav" />
-          {/* CTA hidden on small screens — overflowed on mobile.
-              Logo and link to /generator already accessible via the hero CTA. */}
-          <Link href="/generator" className="btn btn-accent hidden md:inline-flex">
+          {/* CTA hidden on mobile (overflows). See globals.css media query. */}
+          <Link href="/generator" className="btn btn-accent nav-cta">
             {t("ctaBook")} <ArrowRight size={14} />
           </Link>
         </div>


### PR DESCRIPTION
Tailwind hidden class wasn't being applied. Switched to custom .nav-cta class with media query in globals.css — same pattern as .nav-links.