### PR TITLE
docs: refresh CHANGELOG (v0.2.0) and QUICK_START (9 questions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,103 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/), versioning [Se
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-04
+
 ### Ajouté
-- **USE_CASES.md** — 9 cas d'usage concrets (greenfield / overlay / atelier / talk / standardisation équipe / onboarding legacy / mission consulting / hackathon / migration depuis Cursor)
-- **SECURITY.md** — politique de sécurité, modèle de menace, surface d'attaque
-- **README.md** badges CI / License / Vercel / Issues + section Cas d'usage + section Roadmap pointant vers les Issues GitHub
+
+**Questionnaire**
+- 9 questions au total (était 6) : ajout designSystem, extras (fichiers complémentaires), license, colors, teamSetup
+- Step 2 inclut désormais une question dédiée **Team setup** (ajoute CONTRIBUTING.md, CODEOWNERS, PR/issue templates)
+- Step 7 inclut un **ColorPicker** (palette primary + accent + custom hex + preview live)
+- Step 8 propose 7 fichiers extras (.editorconfig, .prettierrc.json, Makefile, Dockerfile, docker-compose.yml, .vscode/settings.json, .github/workflows/ci.yml)
+- Step 9 propose 4 licenses (MIT, Apache-2.0, AGPL-3.0, none)
+- Live preview du file tree pendant la sélection (FileTreePreview, FileCounter)
+
+**Agents (10 au total, était 4)**
+- `pr-reviewer` (Opus xhigh) — review une PR end-to-end
+- `db-migration-reviewer` (Opus xhigh) — review migrations Prisma/Alembic/Drizzle
+- `a11y-auditor` (Sonnet) — audit WCAG 2.2 AA via Playwright MCP
+- `doc-writer` (Sonnet) — écrit ou met à jour la doc
+- `dependency-updater` (Sonnet, **stack-aware**) — variantes Node/Python/Go/Rust + default
+- `test-writer` (Sonnet, **stack-aware**) — variantes node-web/node-server/python/go/rust + default
+- Frontmatter complet sur tous les agents (Anthropic 2026) : `name + description + model + effort + color + tools`
+
+**Skills (8 au total, était 3)**
+- `/release` — bump version + CHANGELOG + tag + publish
+- `/standup` — synthèse quotidienne (commits + PRs + tickets)
+- `/pr-review` — review une PR par numéro
+- `/test-coverage` — run coverage + suggère 3 tests prioritaires
+- `/doc-update` — scan doc obsolète + 5 fixes
+
+**Hooks (3 au total, était 2)**
+- `session-start-context.sh` — re-injecte CLAUDE.md + git status après `:compact` (matcher `startup|resume|compact`)
+
+**Stack-aware substitution (CLAUDE.md)**
+- Pré-remplit la section Stack (Frontend/Backend) selon les choix du questionnaire
+- Pré-remplit le bloc Commands (dev/build/test/lint) par stack (uvicorn pour FastAPI, pnpm pour Next.js, cargo pour Rust, etc.)
+- Structure WHAT / WHY / HOW conforme aux best practices Anthropic 2026 (https://www.humanlayer.dev/blog/writing-a-good-claude-md)
+
+**MCPs configurables (12 au total, était 4)**
+- Ajout : vercel, supabase, stripe, postgres, slack, github, linear, sentry, figma, playwright, context7, notion
+- Filtrage automatique : seuls les MCPs cochés apparaissent dans le `.mcp.json`
+
+**SEO + accessibilité publique**
+- `app/robots.ts` (Next.js metadata API)
+- `app/sitemap.ts` avec hreflang FR/EN
+- `app/icon.svg` + `app/apple-icon.svg` (brand mark)
+- `app/[locale]/opengraph-image.tsx` (OG image dynamique 1200×630 par locale)
+- `generateMetadata` : canonical URLs, hreflang alternates, twitter card, robots directives
+- JSON-LD `SoftwareApplication` dans le `<body>` (rich snippets Google)
+
+**Sécurité production**
+- `lib/rate-limit.ts` : token bucket en mémoire, 20 req/min/IP sur `/api/generate`
+- Body size cap : 32 KB sur `/api/generate` (rejet 413)
+- pnpm overrides : esbuild >=0.25.0, vite >=6.3.6, postcss >=8.5.13, @eslint/plugin-kit >=0.3.4
+
+**Tests**
+- Vitest 4.x configuré (`vitest.config.ts`)
+- 5 unit tests sur `lib/rate-limit.ts`
+- 5 E2E tests sur `/api/generate` (skippables via `SKIP_E2E=1`)
+- CI exécute les unit tests sur chaque PR
+
+**i18n**
+- Bilingue FR (default) + EN via `next-intl`, `localePrefix: as-needed`
+- Toutes les pages, composants et messages de validation traduits
+
+**Branch protection**
+- Ruleset GitHub `protect-main` : pull_request requis (0 reviews requis, self-merge OK), no deletion, no force-push
+- Bypass admin en mode `pull_request` uniquement (pas de push direct)
+
+**DX**
+- `.env.example`
+- `.github/dependabot.yml` (weekly grouped npm + github-actions updates)
+- `prettier` + `.prettierrc.json` + `.prettierignore`
+- Scripts npm : `format`, `format:check`, `test`, `test:watch`
+
+**Pivot landing**
+- Refonte de la landing en produit-first (était cabinet de conseil)
+- Hero stats reflètent la réalité : 9 questions, 14 stacks, 10 agents, 12 MCPs
+- Sections Method/Expertise/Personas/Process/UseCases/FAQ/CTA réécrites
+- Footer avec liens GitHub réels (était `href="#"`)
+
+### Corrigé
+
+- README + USE_CASES + landing : alignement "9 questions" partout (était mélange 6/9)
+- Nav anchors : utilisation de Link `next-intl` avec `/#anchor` pour fonctionner depuis n'importe quelle page
+- Mobile : Nav CTA `nav-cta` caché < 768px via `display: none !important`
+- Mobile : grids 2 colonnes du landing collapse en 1 col < 768px (root cause : React render `minmax(0, 1fr)` avec espace, sélecteurs CSS le cherchaient sans espace)
+- ColorPicker preview : fond clair forcé (#F8F7F4) pour rester lisible en dark mode
+- Method timeline : labels SUMMIT/CAMP DE BASE `nowrap` + offset -40 pour ne plus chevaucher les markers
+- Step 8 (extras) : `break-all` sur les noms de fichiers longs (`.github/workflows/ci.yml`)
+- 0 vulnerabilité Dependabot (next 16.0 → 16.2.4 high CVE, esbuild + vite + postcss + plugin-kit)
+- `teammateMode: "auto"` (était `"tmux"` qui forçait Opus 4.7)
+- Em dashes (`—`) retirés de toute la copy UI : 45 occurrences sur messages FR + EN + composants landing
+
+## [0.1.0] - 2026-05-03
+
+### Ajouté
 - App Next.js 16 + Tailwind v4 + Shadcn-style components
-- One-page marketing avec questionnaire 7 étapes
+- One-page marketing avec questionnaire 6 étapes initial
 - API `/api/generate` qui streame un `.zip` projet personnalisé
 - Templates `greenfield/` (nouveau projet) et `overlay/` (projet existant)
 - Script `install.sh` dual-mode avec détection auto du stack
@@ -23,14 +114,5 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/), versioning [Se
 - `.mcp.json` avec Notion + Context7 actifs
 - GitHub Actions CI : lint + typecheck + build + validation templates + tests hooks
 - Templates issues + PR
-- CONTRIBUTING.md + CODE_OF_CONDUCT.md + CHANGELOG.md
+- USE_CASES.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, CHANGELOG.md
 - License MIT
-
-### Corrigé
-- `pre-edit-secrets.sh` ne bloque plus les fichiers `.env.example` (faux positif)
-- `pre-edit-secrets.sh` fail-soft si `jq` est absent (au lieu de tout casser)
-- `settings.json` : suppression du champ invalide `experimental.agentTeams` au profit de la combinaison officielle `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` + `teammateMode`
-
-## [0.1.0] - 2026-05-03
-
-- Bootstrap initial du repo

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -9,20 +9,22 @@
                 │  cordee-ia.vercel.app/generator     │
                 └──────────────┬──────────────────────┘
                                │
-                          (7 questions)
+                          (9 questions, 2 min)
                                │
                                ▼
                 ┌─────────────────────────────────────┐
                 │   <ton-projet>.zip                  │
                 │   .claude/  CLAUDE.md  DESIGN.md    │
                 │   .mcp.json  hooks  agents  skills  │
+                │   + extras + LICENSE + README       │
                 └──────────────┬──────────────────────┘
                                │
                           unzip + claude
                                │
                                ▼
                 ┌─────────────────────────────────────┐
-                │   /kickoff                          │
+                │   /kickoff (greenfield)             │
+                │   /audit   (overlay)                │
                 │   tu codes ta feature               │
                 └─────────────────────────────────────┘
 ```
@@ -33,18 +35,19 @@
 
 [cordee-ia.vercel.app/generator](https://cordee-ia.vercel.app/generator)
 
-### 2. Réponds aux 7 questions
+### 2. Réponds aux 9 questions
 
-Mode complet (~ 2 minutes) ou mode express (~ 30 secondes) si tu es pressé.
-Tu choisis :
+Compte 2 minutes. Tu choisis dans cet ordre :
 
-- Nom de projet + description
-- Mode (greenfield from scratch / overlay sur repo existant)
-- Stack (Next.js, NestJS, FastAPI, Django, Rails, Go, etc.)
-- Agents Claude à inclure (researcher, challenger, reviewer, doc-writer, etc.)
-- Skills (`/kickoff`, `/audit`, `/design-handoff`, `/release`, etc.)
-- MCPs (Notion, Linear, Sentry, Playwright, Figma, etc.)
-- Design system (Cordée granite + cuivre, custom, ou skip)
+1. **Nom de projet + description**
+2. **Mode** (greenfield from scratch ou overlay sur repo existant) + option Team setup
+3. **Stack** (14 au choix : Next.js, NestJS, FastAPI, Django, Flask, Go, Rust, Vue, SvelteKit, Astro, Remix, Hono, Express, ou aucune)
+4. **Agents Claude** (10 au choix, dont test-writer + dependency-updater stack-aware)
+5. **Skills** (8 au choix : `/kickoff`, `/audit`, `/design-handoff`, `/release`, `/standup`, `/pr-review`, `/test-coverage`, `/doc-update`)
+6. **MCPs** (12 au choix : Notion, Sentry, Figma, Playwright, GitHub, Linear, Vercel, Supabase, Stripe, Postgres, Slack, Context7)
+7. **Design system** + couleurs (exemple Cordée, template vide à 9 sections, ou skip + ColorPicker primary/accent)
+8. **Fichiers complémentaires** (.editorconfig, Prettier, Makefile, Dockerfile, docker-compose, .vscode, GitHub Actions CI)
+9. **License** (MIT, Apache-2.0, AGPL-3.0, ou aucune)
 
 ### 3. Télécharge le `.zip`
 


### PR DESCRIPTION
Brings docs in line with the actual repo state. CHANGELOG v0.2.0 captures every change since v0.1.0. QUICK_START fixes stale '7 questions' → '9 questions'.