### PR TITLE
feat: Challenger pre-download panel (closes #34)

### DIFF
--- a/components/Questionnaire.tsx
+++ b/components/Questionnaire.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_COLORS,
   type ColorsValue,
 } from "@/components/generator/ColorPicker";
+import { ChallengerPanel } from "@/components/generator/ChallengerPanel";
 
 // ─── Schema ────────────────────────────────────────────────────────────────
 
@@ -779,6 +780,24 @@ export function Questionnaire({ onValuesChange }: QuestionnaireProps = {}) {
           <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-[10px] p-3">
             {error}
           </div>
+        )}
+
+        {step === TOTAL_STEPS && (
+          <ChallengerPanel
+            input={{
+              projectName: watch("projectName") ?? "",
+              projectDescription: watch("projectDescription") ?? "",
+              mode: watch("mode") ?? "greenfield",
+              stack: watch("stack") ?? [],
+              agents: watch("agents") ?? [],
+              skills: watch("skills") ?? [],
+              mcps: watch("mcps") ?? [],
+              designSystem: watch("designSystem") ?? "empty-template",
+              extras: watch("extras") ?? [],
+              license: watch("license") ?? "MIT",
+              teamSetup: watch("teamSetup") ?? false,
+            }}
+          />
         )}
 
         <div className="flex items-center justify-between pt-4 border-t border-[var(--color-border)]">

--- a/components/generator/ChallengerPanel.tsx
+++ b/components/generator/ChallengerPanel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  runChallenger,
+  type ChallengerInput,
+  type Finding,
+} from "@/lib/challenger-rules";
+
+interface Props {
+  /** Current questionnaire state, used to compute findings on render. */
+  input: ChallengerInput;
+}
+
+/**
+ * ChallengerPanel
+ *
+ * Pre-download critique panel rendered at the end of step 9, above the
+ * "Download zip" button. Reads the current questionnaire state, runs the
+ * deterministic rule engine, and surfaces findings as dismissible cards.
+ *
+ * Design notes:
+ *   - Findings phrased as questions, not verdicts (user keeps agency).
+ *   - Each card has a × to dismiss (panel never blocks submission).
+ *   - Two severities: warn (orange) + info (muted).
+ *   - English-only at launch (per challenger review). FR keys can be added
+ *     later when usage validates the feature.
+ */
+export function ChallengerPanel({ input }: Props) {
+  const t = useTranslations("Challenger");
+  const findings = useMemo<Finding[]>(() => runChallenger(input), [input]);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const visible = findings.filter((f) => !dismissed.has(f.ruleId));
+
+  if (visible.length === 0) return null;
+
+  return (
+    <aside
+      className="rounded-[12px] border p-5 space-y-3"
+      style={{
+        borderColor: "color-mix(in oklch, var(--color-accent) 30%, transparent)",
+        background:
+          "color-mix(in oklch, var(--color-accent) 4%, var(--color-background))",
+      }}
+      aria-label={t("panelLabel")}
+    >
+      <header className="flex items-baseline justify-between gap-3">
+        <div>
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.12em]"
+            style={{ color: "var(--color-accent)" }}
+          >
+            {t("eyebrow")}
+          </div>
+          <p className="text-sm mt-1 text-[var(--color-foreground)]">
+            {t("intro", { count: visible.length })}
+          </p>
+        </div>
+      </header>
+
+      <ul className="space-y-2 list-none p-0 m-0">
+        {visible.map((f) => (
+          <li
+            key={f.ruleId}
+            className="flex gap-3 items-start rounded-[8px] p-3"
+            style={{
+              background: "var(--color-background)",
+              border: "1px solid var(--color-border)",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              className="font-mono text-xs uppercase tracking-wider mt-0.5 shrink-0"
+              style={{
+                color:
+                  f.severity === "warn" ? "var(--color-accent)" : "var(--color-muted)",
+                minWidth: 36,
+              }}
+            >
+              {f.severity === "warn" ? "warn" : "info"}
+            </span>
+            <span className="text-sm leading-relaxed flex-1 text-[var(--color-foreground)]">
+              {t(`rules.${f.messageKey}`, f.vars ?? {})}
+            </span>
+            <button
+              type="button"
+              onClick={() =>
+                setDismissed((prev) => {
+                  const next = new Set(prev);
+                  next.add(f.ruleId);
+                  return next;
+                })
+              }
+              aria-label={t("dismiss")}
+              className="font-mono text-xs opacity-50 hover:opacity-100 transition-opacity shrink-0"
+              style={{ color: "var(--color-muted)" }}
+            >
+              ✕
+            </button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/lib/challenger-rules.test.ts
+++ b/lib/challenger-rules.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { runChallenger, KNOWN_RULE_IDS, type ChallengerInput } from "./challenger-rules";
+
+const baseline: ChallengerInput = {
+  projectName: "test",
+  projectDescription: "",
+  mode: "greenfield",
+  stack: ["nextjs"],
+  agents: ["researcher"],
+  skills: ["kickoff"],
+  mcps: ["notion"],
+  designSystem: "empty-template",
+  extras: [],
+  license: "MIT",
+  teamSetup: false,
+};
+
+const fire = (overrides: Partial<ChallengerInput>) =>
+  runChallenger({ ...baseline, ...overrides }).map((f) => f.ruleId);
+
+describe("runChallenger", () => {
+  // ── WARN rules ────────────────────────────────────────────────────
+
+  it("manyAgentsNoMcps: fires when 5+ agents and 0 MCPs", () => {
+    const ids = fire({
+      agents: ["researcher", "challenger", "reviewer", "test-writer", "doc-writer"],
+      mcps: [],
+    });
+    expect(ids).toContain("manyAgentsNoMcps");
+  });
+
+  it("opusHeavy: fires when 3+ Opus-tier agents are picked", () => {
+    const ids = fire({
+      agents: ["challenger", "reviewer", "pr-reviewer", "db-migration-reviewer"],
+    });
+    expect(ids).toContain("opusHeavy");
+  });
+
+  it("frontendNoDesign: fires when frontend stack is picked but DESIGN.md is skipped", () => {
+    const ids = fire({ stack: ["nextjs"], designSystem: "skip" });
+    expect(ids).toContain("frontendNoDesign");
+  });
+
+  it("testWriterNoCoverage: fires when test-writer agent picked without /test-coverage skill", () => {
+    const ids = fire({ agents: ["test-writer"], skills: ["kickoff"] });
+    expect(ids).toContain("testWriterNoCoverage");
+  });
+
+  it("prReviewerNoSkill: fires when pr-reviewer agent picked without /pr-review skill", () => {
+    const ids = fire({ agents: ["pr-reviewer"], skills: ["kickoff"] });
+    expect(ids).toContain("prReviewerNoSkill");
+  });
+
+  it("dbReviewerNoDbMcp: fires when db-migration-reviewer picked without postgres/supabase MCP", () => {
+    const ids = fire({ agents: ["db-migration-reviewer"], mcps: ["notion"] });
+    expect(ids).toContain("dbReviewerNoDbMcp");
+  });
+
+  it("greenfieldNoKickoff: fires on greenfield without /kickoff skill", () => {
+    const ids = fire({ mode: "greenfield", skills: [] });
+    expect(ids).toContain("greenfieldNoKickoff");
+  });
+
+  it("overlayNoAudit: fires on overlay without /audit skill", () => {
+    const ids = fire({ mode: "overlay", skills: ["kickoff"] });
+    expect(ids).toContain("overlayNoAudit");
+  });
+
+  it("teamSetupSoloAgent: fires when teamSetup=true with <= 1 agent", () => {
+    const ids = fire({ teamSetup: true, agents: ["researcher"] });
+    expect(ids).toContain("teamSetupSoloAgent");
+  });
+
+  // ── INFO rules ────────────────────────────────────────────────────
+
+  it("noAgents: fires when 0 agents picked", () => {
+    const ids = fire({ agents: [] });
+    expect(ids).toContain("noAgents");
+  });
+
+  it("noSkills: fires when 0 skills picked", () => {
+    const ids = fire({ skills: [], mode: "overlay" });
+    // mode overlay so we don't double-fire greenfieldNoKickoff
+    expect(ids).toContain("noSkills");
+  });
+
+  it("noStack: fires when stack is empty or only 'none'", () => {
+    expect(fire({ stack: [] })).toContain("noStack");
+    expect(fire({ stack: ["none"] })).toContain("noStack");
+  });
+
+  // ── Aggregator behaviour ──────────────────────────────────────────
+
+  it("returns warn findings before info findings", () => {
+    const findings = runChallenger({
+      ...baseline,
+      agents: [],
+      skills: [],
+      mode: "overlay",
+    });
+    const severities = findings.map((f) => f.severity);
+    const firstInfo = severities.indexOf("info");
+    const lastWarn = severities.lastIndexOf("warn");
+    if (firstInfo !== -1 && lastWarn !== -1) {
+      expect(lastWarn).toBeLessThan(firstInfo);
+    }
+  });
+
+  it("returns no findings on a sane baseline (canary)", () => {
+    const findings = runChallenger(baseline);
+    // Baseline has empty-template design + nextjs + 1 agent + kickoff skill +
+    // notion MCP. Minor info findings (e.g. "no a11y-auditor") may fire but
+    // no warn-level finding should.
+    const warns = findings.filter((f) => f.severity === "warn");
+    expect(warns).toHaveLength(0);
+  });
+
+  it("every finding has a known ruleId (no typos in production rules)", () => {
+    const knownSet = new Set(KNOWN_RULE_IDS);
+    // Generate a payload that triggers many rules at once.
+    const findings = runChallenger({
+      ...baseline,
+      agents: ["test-writer", "pr-reviewer", "db-migration-reviewer", "challenger", "reviewer"],
+      skills: [],
+      mcps: [],
+      stack: ["nextjs"],
+      designSystem: "skip",
+      teamSetup: true,
+    });
+    for (const f of findings) {
+      expect(knownSet.has(f.ruleId as (typeof KNOWN_RULE_IDS)[number])).toBe(true);
+    }
+  });
+});

--- a/lib/challenger-rules.ts
+++ b/lib/challenger-rules.ts
@@ -1,0 +1,227 @@
+/**
+ * Challenger rule engine.
+ *
+ * Pure deterministic logic — NO LLM call. Reads the questionnaire payload,
+ * applies a fixed set of rules, returns Findings. Used by the
+ * <ChallengerPanel> rendered at the end of step 9 (before "Download zip").
+ *
+ * Design principles (after challenger review):
+ *   - Two severities only: `warn` (worth reading) + `info` (FYI).
+ *   - No `good` / 🟢 self-congratulation messages — saves clutter.
+ *   - Phrasing is QUESTION not verdict ("Are you sure …?" not "Wrong: …").
+ *     The user keeps agency; we surface the trade-off, they decide.
+ *   - Each rule cites the WHY (Anthropic doc or pragmatic reasoning) so
+ *     dismissals are informed, not blind.
+ *   - Findings are individually dismissible — the panel never blocks
+ *     submission and the rule engine doesn't know about dismissals
+ *     (UI concern).
+ */
+
+export type Severity = "warn" | "info";
+
+export interface Finding {
+  /** Stable identifier so tests + i18n can lookup the rule. */
+  ruleId: string;
+  severity: Severity;
+  /** Translation key under `Challenger.rules.<ruleId>`. */
+  messageKey: string;
+  /** Optional vars for next-intl interpolation. */
+  vars?: Record<string, string | number>;
+}
+
+/**
+ * Minimal shape of the questionnaire payload. We don't import the full
+ * Payload type from the API to keep the lib decoupled.
+ */
+export interface ChallengerInput {
+  projectName: string;
+  projectDescription: string;
+  mode: "greenfield" | "overlay";
+  stack: string[];
+  agents: string[];
+  skills: string[];
+  mcps: string[];
+  designSystem: "use-example" | "empty-template" | "skip";
+  extras: string[];
+  license: string;
+  teamSetup: boolean;
+}
+
+const FRONTEND_STACKS = ["nextjs", "vue", "sveltekit", "astro", "remix"];
+const OPUS_AGENTS = ["challenger", "reviewer", "pr-reviewer", "db-migration-reviewer"];
+
+const RULES: Array<(p: ChallengerInput) => Finding | null> = [
+  // ── WARN ──────────────────────────────────────────────────────────
+  (p) => {
+    if (p.agents.length >= 5 && p.mcps.length === 0) {
+      return {
+        ruleId: "manyAgentsNoMcps",
+        severity: "warn",
+        messageKey: "manyAgentsNoMcps",
+        vars: { count: p.agents.length },
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    const opusCount = p.agents.filter((a) => OPUS_AGENTS.includes(a)).length;
+    if (opusCount >= 3) {
+      return {
+        ruleId: "opusHeavy",
+        severity: "warn",
+        messageKey: "opusHeavy",
+        vars: { count: opusCount },
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    const hasFrontend = p.stack.some((s) => FRONTEND_STACKS.includes(s));
+    if (hasFrontend && p.designSystem === "skip") {
+      return {
+        ruleId: "frontendNoDesign",
+        severity: "warn",
+        messageKey: "frontendNoDesign",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.agents.includes("test-writer") && !p.skills.includes("test-coverage")) {
+      return {
+        ruleId: "testWriterNoCoverage",
+        severity: "warn",
+        messageKey: "testWriterNoCoverage",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.agents.includes("pr-reviewer") && !p.skills.includes("pr-review")) {
+      return {
+        ruleId: "prReviewerNoSkill",
+        severity: "warn",
+        messageKey: "prReviewerNoSkill",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (
+      p.agents.includes("db-migration-reviewer") &&
+      !p.mcps.includes("postgres") &&
+      !p.mcps.includes("supabase")
+    ) {
+      return {
+        ruleId: "dbReviewerNoDbMcp",
+        severity: "warn",
+        messageKey: "dbReviewerNoDbMcp",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.mode === "greenfield" && !p.skills.includes("kickoff")) {
+      return {
+        ruleId: "greenfieldNoKickoff",
+        severity: "warn",
+        messageKey: "greenfieldNoKickoff",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.mode === "overlay" && !p.skills.includes("audit")) {
+      return {
+        ruleId: "overlayNoAudit",
+        severity: "warn",
+        messageKey: "overlayNoAudit",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.teamSetup && p.agents.length <= 1) {
+      return {
+        ruleId: "teamSetupSoloAgent",
+        severity: "warn",
+        messageKey: "teamSetupSoloAgent",
+      };
+    }
+    return null;
+  },
+
+  // ── INFO ──────────────────────────────────────────────────────────
+  (p) => {
+    if (p.agents.length === 0) {
+      return {
+        ruleId: "noAgents",
+        severity: "info",
+        messageKey: "noAgents",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.skills.length === 0) {
+      return {
+        ruleId: "noSkills",
+        severity: "info",
+        messageKey: "noSkills",
+      };
+    }
+    return null;
+  },
+
+  (p) => {
+    if (p.stack.length === 0 || p.stack.every((s) => s === "none")) {
+      return {
+        ruleId: "noStack",
+        severity: "info",
+        messageKey: "noStack",
+      };
+    }
+    return null;
+  },
+];
+
+/**
+ * Run all rules against the input.
+ * Findings are returned `warn` first, then `info`.
+ */
+export function runChallenger(input: ChallengerInput): Finding[] {
+  const findings: Finding[] = [];
+  for (const rule of RULES) {
+    const f = rule(input);
+    if (f) findings.push(f);
+  }
+  return findings.sort((a, b) => {
+    if (a.severity === b.severity) return 0;
+    return a.severity === "warn" ? -1 : 1;
+  });
+}
+
+/** Exposed for tests — the full list of rule IDs the engine knows about. */
+export const KNOWN_RULE_IDS = [
+  "manyAgentsNoMcps",
+  "opusHeavy",
+  "frontendNoDesign",
+  "testWriterNoCoverage",
+  "prReviewerNoSkill",
+  "dbReviewerNoDbMcp",
+  "greenfieldNoKickoff",
+  "overlayNoAudit",
+  "teamSetupSoloAgent",
+  "noAgents",
+  "noSkills",
+  "noStack",
+] as const;

--- a/messages/en.json
+++ b/messages/en.json
@@ -283,6 +283,26 @@
     "copyright": "© 2026 Julien Devot, Cordée.IA is MIT-licensed",
     "version": "v.2026.05, made in France"
   },
+  "Challenger": {
+    "panelLabel": "Pre-download review",
+    "eyebrow": "Challenger",
+    "intro": "{count, plural, =1 {# question on your config before you download.} other {# questions on your config before you download.}}",
+    "dismiss": "Dismiss",
+    "rules": {
+      "manyAgentsNoMcps": "You picked {count} agents but zero MCPs. Agents like pr-reviewer or db-migration-reviewer typically need Notion, Linear, GitHub or Postgres MCPs to do useful work. Intentional?",
+      "opusHeavy": "{count} Opus-tier agents selected. Anthropic's 90/10 routing recommends keeping Opus for heavy reasoning only (~10% of tasks). Heavy Opus use multiplies cost. Are all {count} truly worth Opus over Sonnet 4.6?",
+      "frontendNoDesign": "Frontend stack picked but DESIGN.md is set to skip. Claude Design will not be able to scaffold the UI from your starter. Consider 'empty-template' at minimum.",
+      "testWriterNoCoverage": "test-writer agent picked but /test-coverage skill is missing. The agent will work, but you lose the day-1 'run coverage + suggest 3 priority tests' workflow.",
+      "prReviewerNoSkill": "pr-reviewer agent picked but /pr-review skill is missing. The agent works ad-hoc, but the skill gives you a quick `/pr-review <number>` slash command.",
+      "dbReviewerNoDbMcp": "db-migration-reviewer agent picked but no DB MCP (Postgres or Supabase). The agent reviews migration files but can't introspect your live schema. Worth pairing with a DB MCP.",
+      "greenfieldNoKickoff": "Greenfield mode without /kickoff skill. Without it, you start with a blank CLAUDE.md and have to manually scaffold the project structure. Recommended.",
+      "overlayNoAudit": "Overlay mode without /audit skill. Without it, Claude won't have a fast 'map this codebase' first prompt. Recommended for legacy onboarding.",
+      "teamSetupSoloAgent": "Team setup is on (CONTRIBUTING.md, CODEOWNERS, PR templates) but you only picked 1 agent. The team artifacts will ship but feel orphaned. Add 2-3 more agents or turn team setup off.",
+      "noAgents": "No agents selected. Claude Code will work, but you'll only get the slash skills. Adding researcher and challenger costs nothing and unlocks the typical reasoning patterns.",
+      "noSkills": "No skills selected. Claude Code will work via raw prompts, but you'll miss /kickoff, /audit and the day-1 workflow shortcuts.",
+      "noStack": "No stack selected. CLAUDE.md commands will be empty placeholders, and stack-aware agents (test-writer, dependency-updater) will fall back to a generic variant."
+    }
+  },
   "Generator": {
     "Hero": {
       "badge": "Cordée.IA, open source, MIT",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -283,6 +283,26 @@
     "copyright": "© 2026 Julien Devot, Cordée.IA est sous licence MIT",
     "version": "v.2026.05, fait en France"
   },
+  "Challenger": {
+    "panelLabel": "Revue pré-téléchargement",
+    "eyebrow": "Challenger",
+    "intro": "{count, plural, =1 {# question sur ta config avant de télécharger.} other {# questions sur ta config avant de télécharger.}}",
+    "dismiss": "Ignorer",
+    "rules": {
+      "manyAgentsNoMcps": "Tu as coché {count} agents mais zéro MCP. Des agents comme pr-reviewer ou db-migration-reviewer ont besoin de Notion, Linear, GitHub ou Postgres pour bosser sérieusement. Volontaire ?",
+      "opusHeavy": "{count} agents Opus cochés. Le routing 90/10 d'Anthropic recommande de garder Opus pour le reasoning lourd (~10% des tâches). Tous les {count} sont vraiment plus utiles en Opus qu'en Sonnet 4.6 ?",
+      "frontendNoDesign": "Stack frontend choisie mais DESIGN.md est sur 'skip'. Claude Design ne pourra pas scaffolder l'UI. Au minimum 'empty-template'.",
+      "testWriterNoCoverage": "Agent test-writer coché mais skill /test-coverage absent. L'agent fonctionne, mais tu perds le workflow day-1 'lance coverage + propose 3 tests prioritaires'.",
+      "prReviewerNoSkill": "Agent pr-reviewer coché mais skill /pr-review absent. L'agent marche à la demande, mais la skill donne le raccourci /pr-review <numero>.",
+      "dbReviewerNoDbMcp": "Agent db-migration-reviewer coché mais pas de MCP DB (Postgres ou Supabase). L'agent review les fichiers de migration mais ne peut pas inspecter le schéma live.",
+      "greenfieldNoKickoff": "Greenfield sans skill /kickoff. Sans, tu démarres avec un CLAUDE.md vide et tu scaffoldes manuellement.",
+      "overlayNoAudit": "Overlay sans skill /audit. Claude n'aura pas de 'map this codebase' day-1. Recommandé pour l'onboarding legacy.",
+      "teamSetupSoloAgent": "Team setup activé (CONTRIBUTING.md, CODEOWNERS, PR templates) mais 1 seul agent. Les artefacts d'équipe semblent orphelins. Ajoute 2-3 agents ou coupe team setup.",
+      "noAgents": "Aucun agent. Claude Code marche en raw, mais tu perds les patterns de reasoning. researcher + challenger ne coûtent rien à inclure.",
+      "noSkills": "Aucune skill. Tu perds /kickoff, /audit et les raccourcis day-1.",
+      "noStack": "Aucune stack. Les commands de CLAUDE.md restent vides, et les agents stack-aware (test-writer, dependency-updater) tombent en variant générique."
+    }
+  },
   "Generator": {
     "Hero": {
       "badge": "Cordée.IA, open source, MIT",


### PR DESCRIPTION
Implements issue #34 with a deterministic rule engine + dismissible cards in step 9. 12 rules, 2 severities (warn/info), questions-not-verdicts framing. Issue #35 cut after teammate challenger review (YAGNI). Engine reusable for #36 when ready.

Tests: 15 unit tests covering each rule + aggregator behavior + sane-baseline canary.